### PR TITLE
Add tests for energyTrend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/api/energyTrend.js
+++ b/api/energyTrend.js
@@ -18,6 +18,10 @@ export default async function handler(req, res) {
       }
     });
 
+    if (!response.ok) {
+      throw new Error(`External API error: ${response.status}`);
+    }
+
     const data = await response.json();
 
     res.status(200).json({ success: true, data });

--- a/api/energyTrend.test.js
+++ b/api/energyTrend.test.js
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from './energyTrend.js';
+
+function createRes() {
+  return {
+    statusCode: 0,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+    }
+  };
+}
+
+const originalFetch = global.fetch;
+
+test('returns 400 when parameters are missing', async () => {
+  const req = { method: 'GET', query: { plantId: '1', type: 'day', date: '2023-01-01' } };
+  const res = createRes();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(res.body, { error: 'Missing required parameters' });
+});
+
+test('handles non-ok fetch with 500 error', async () => {
+  const req = { method: 'GET', query: { plantId: '1', type: 'day', date: '2023-01-01', token: 'abc' } };
+  const res = createRes();
+
+  global.fetch = async () => ({ ok: false, status: 500 });
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.error, 'Failed to fetch energy trend');
+});
+
+test('returns 200 and success true with valid fetch', async () => {
+  const mockData = { foo: 'bar' };
+  const req = { method: 'GET', query: { plantId: '1', type: 'day', date: '2023-01-01', token: 'abc' } };
+  const res = createRes();
+
+  global.fetch = async () => ({ ok: true, json: async () => mockData });
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, { success: true, data: mockData });
+});
+
+test.after(() => {
+  global.fetch = originalFetch;
+});

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "axintele-shine-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "axintele-shine-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "node-fetch": "^3.3.2"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "engines": {
     "node": ">=18.0.0"
   }


### PR DESCRIPTION
## Summary
- handle non-OK responses in `energyTrend` API
- add comprehensive tests for `energyTrend` API scenarios
- add npm test script using Node's built-in test runner

## Testing
- `npm test --prefix api`

------
https://chatgpt.com/codex/tasks/task_e_6897bfd35e5c83319c0f7b2102d22115