### PR TITLE
Document endpoints and env-based login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Shine API Proxy
+
+Questo progetto fornisce due endpoint proxy per interagire con il servizio Growatt/"ShinePhone".
+
+## Variabili d'ambiente
+Le credenziali e le informazioni dell'impianto non vengono codificate nel sorgente, ma lette da variabili d'ambiente:
+
+- `SHINE_USERNAME`
+- `SHINE_PASSWORD`
+- `SHINE_DEVCODE`
+- `SHINE_SERIAL`
+- `SHINE_REGION` (opzionale, predefinito `romania`)
+
+Impostare queste variabili prima di avviare l'applicazione.
+
+## Endpoint
+
+### `/api/shinephone`
+Effettua il login al servizio ShinePhone usando le credenziali fornite tramite variabili d'ambiente e restituisce alcune informazioni di debug.
+
+### `/api/energyTrend`
+Recupera l'andamento energetico di un impianto. Richiede i seguenti parametri query:
+
+- `plantId`: identificativo dell'impianto
+- `type`: tipo di intervallo (ad es. `day`)
+- `date`: data di riferimento (formato `YYYY-MM-DD`)
+- `token`: token ottenuto dal login
+
+Esempio:
+```bash
+curl "https://<host>/api/energyTrend?plantId=123&type=day&date=2024-01-01&token=<TOKEN>"
+```
+
+## Esecuzione
+Installare le dipendenze nella cartella `api` ed avviare il server secondo l'ambiente scelto (ad es. Vercel).

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axintele-shine-api",
   "version": "1.0.0",
-  "description": "Proxy API per ShinePhone - Parco Solare Axintele",
+  "description": "Proxy API per ShinePhone con endpoint login ed energyTrend",
   "type": "module",
   "dependencies": {
     "node-fetch": "^3.3.2"

--- a/api/shinephone.js
+++ b/api/shinephone.js
@@ -4,15 +4,15 @@ export default async function handler(req, res) {
   try {
     const params = {
       action: 'login',
-      userName: 'Dsf',
-      userPassword: '123456',
+      userName: process.env.SHINE_USERNAME,
+      userPassword: process.env.SHINE_PASSWORD,
       language: 'en',
       isWeb: 'true',
       client: 'ios',
-      region: 'romania',
+      region: process.env.SHINE_REGION || 'romania',
       v: '4.0.2',
-      devcode: 'GPG0CLU18P',
-      serialNum: 'GPG0CLU18P'
+      devcode: process.env.SHINE_DEVCODE,
+      serialNum: process.env.SHINE_SERIAL
     };
 
     const response = await fetch('https://server.growatt.com/login', {


### PR DESCRIPTION
## Summary
- mention energyTrend in package description and document endpoints
- read ShinePhone credentials from environment variables
- add README with endpoint and credential instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897bfcebe9083319ee249ea6358b5e7