### PR TITLE
Handle error responses in energy trend API

### DIFF
--- a/api/energyTrend.js
+++ b/api/energyTrend.js
@@ -18,6 +18,14 @@ export default async function handler(req, res) {
       }
     });
 
+    if (!response.ok) {
+      return res.status(response.status).json({
+        error: 'Failed to fetch energy trend',
+        status: response.status,
+        statusText: response.statusText
+      });
+    }
+
     const data = await response.json();
 
     res.status(200).json({ success: true, data });


### PR DESCRIPTION
## Summary
- validate response.ok when fetching energy trend data
- return detailed error info when remote API responds with an error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897bfcd74d48331bda6678e19475d93