### PR TITLE
Correct region casing for Romania

### DIFF
--- a/api/shinephone.js
+++ b/api/shinephone.js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
       language: 'en',
       isWeb: 'true',
       client: 'ios',
-      region: 'romania',
+      region: 'Romania',
       v: '4.0.2',
       devcode: 'GPG0CLU18P',
       serialNum: 'GPG0CLU18P'


### PR DESCRIPTION
## Summary
- use proper capitalization for the Romania region in ShinePhone API params

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6897bfcb8fc08331928c6e89261557a7