### PR TITLE
Handle non-OK responses in energyTrend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/api/energyTrend.js
+++ b/api/energyTrend.js
@@ -18,6 +18,14 @@ export default async function handler(req, res) {
       }
     });
 
+    if (!response.ok) {
+      return res.status(response.status).json({
+        error: 'Failed to fetch energy trend',
+        status: response.status,
+        statusText: response.statusText
+      });
+    }
+
     const data = await response.json();
 
     res.status(200).json({ success: true, data });


### PR DESCRIPTION
## Summary
- Check upstream response status in `energyTrend` handler and return error details when non-200
- Ignore Node.js build artifacts with .gitignore

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897be5166148331bcd83a681d0b46f7